### PR TITLE
Mobile Nav logo bug

### DIFF
--- a/components/nav/index.tsx
+++ b/components/nav/index.tsx
@@ -36,6 +36,13 @@ const MobileNavContent = () => {
 
     return (
         <>
+            <div className={styles.logo}>
+                <img
+                    src={logo.src}
+                    alt="logo"
+                    onClick={() => onItemClick('/')}
+                />
+            </div>
             <Hamburger onClick={setOpen} open={open} />
             <Drawer
                 maskClosable={false}
@@ -103,40 +110,42 @@ const Nav = () => {
 
     return (
         <nav className={styles.Nav}>
-            <div className={styles.logo}>
-                <Link href="/">
-                    <img src={logo.src} alt="logo" />
-                </Link>
-            </div>
             {showMobileNav ? (
                 <MobileNavContent />
             ) : (
-                <ul className={styles.navContent}>
-                    <li
-                        className={
-                            router.pathname.includes('services')
-                                ? styles.active
-                                : ''
-                        }>
-                        <Link href="/services">Services</Link>
-                    </li>
-                    <li
-                        className={
-                            router.pathname.includes('works')
-                                ? styles.active
-                                : ''
-                        }>
-                        <Link href="/works">Works</Link>
-                    </li>
-                    <li
-                        className={
-                            router.pathname.includes('contact')
-                                ? styles.active
-                                : ''
-                        }>
-                        <Link href="/contact">Contact</Link>
-                    </li>
-                </ul>
+                <>
+                    <div className={styles.logo}>
+                        <Link href="/">
+                            <img src={logo.src} alt="logo" />
+                        </Link>
+                    </div>
+                    <ul className={styles.navContent}>
+                        <li
+                            className={
+                                router.pathname.includes('services')
+                                    ? styles.active
+                                    : ''
+                            }>
+                            <Link href="/services">Services</Link>
+                        </li>
+                        <li
+                            className={
+                                router.pathname.includes('works')
+                                    ? styles.active
+                                    : ''
+                            }>
+                            <Link href="/works">Works</Link>
+                        </li>
+                        <li
+                            className={
+                                router.pathname.includes('contact')
+                                    ? styles.active
+                                    : ''
+                            }>
+                            <Link href="/contact">Contact</Link>
+                        </li>
+                    </ul>
+                </>
             )}
         </nav>
     )

--- a/components/views/landing/Landing.module.scss
+++ b/components/views/landing/Landing.module.scss
@@ -132,6 +132,12 @@
 
         @include breakpoints.set-max-width('small') {
             width: 75vw;
+            gap: 2rem;
+            margin-top: 2rem;
+
+            h1 {
+                line-height: initial;
+            }
         }
     }
 


### PR DESCRIPTION
When the mobile nav menu was open, clicking on the logo would break the nav during the routing phase. Removed `Link` and updated mobile nav to use the onClick function the other links were using, that would trigger the transition effects then `router.push('/')` once everything else was done.