### PR TITLE
Page transitions buggy on mobile

### DIFF
--- a/components/nav/index.tsx
+++ b/components/nav/index.tsx
@@ -2,8 +2,10 @@ import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { Drawer } from 'antd'
-import { FaBars } from 'react-icons/fa'
 
+import useBreakpointSize, {
+    MOBILE_BREAKPOINT
+} from '../../utilities/hooks/useBreakpointSize'
 import logo from '../../assets/logo.svg'
 import styles from './Nav.module.scss'
 
@@ -78,28 +80,15 @@ const MobileNavContent = () => {
     )
 }
 
-const mobileBreakpoint = 1000
 const Nav = () => {
     const router = useRouter()
+    const breakpoint = useBreakpointSize()
 
     const [showMobileNav, setShowMobileNav] = useState(false)
 
     useEffect(() => {
-        const onWindowResize = () => {
-            if (window.innerWidth <= mobileBreakpoint) {
-                return setShowMobileNav(true)
-            }
-
-            return setShowMobileNav(false)
-        }
-
-        if (window.innerWidth <= mobileBreakpoint) {
-            setShowMobileNav(true)
-        }
-        window.addEventListener('resize', onWindowResize)
-
-        return () => window.removeEventListener('resize', onWindowResize)
-    }, [])
+        setShowMobileNav(breakpoint === MOBILE_BREAKPOINT)
+    }, [breakpoint])
 
     return (
         <nav className={styles.Nav}>

--- a/components/transition/index.tsx
+++ b/components/transition/index.tsx
@@ -1,8 +1,13 @@
 import { useRouter } from 'next/router'
 import { motion, AnimatePresence } from 'framer-motion'
 
+import useBreakpointSize, {
+    MOBILE_BREAKPOINT
+} from '../../utilities/hooks/useBreakpointSize'
+
 const RouteTransition = ({ children }: { children: any }) => {
     const { asPath } = useRouter()
+    const breakpoint = useBreakpointSize()
 
     const variants = {
         scaleDown: {
@@ -43,6 +48,10 @@ const RouteTransition = ({ children }: { children: any }) => {
                 delay: 0.5
             }
         }
+    }
+
+    if (breakpoint === MOBILE_BREAKPOINT) {
+        return children
     }
 
     return (

--- a/utilities/hooks/useBreakpointSize.ts
+++ b/utilities/hooks/useBreakpointSize.ts
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react'
+
+export const MOBILE_BREAKPOINT = 'mobile'
+export const REGULAR_BREAKPOINT = 'regular'
+const MOBILE_WIDTH = 1000
+
+const useBreakpointSize = () => {
+    const [breakpoint, setBreakpoint] = useState(REGULAR_BREAKPOINT)
+
+    useEffect(() => {
+        function handleResize() {
+            const isMobile = window.innerWidth <= MOBILE_WIDTH
+            setBreakpoint(isMobile ? MOBILE_BREAKPOINT : REGULAR_BREAKPOINT)
+        }
+
+        window.addEventListener('resize', handleResize)
+        handleResize()
+
+        return () => window.removeEventListener('resize', handleResize)
+    }, [])
+    return breakpoint
+}
+
+export default useBreakpointSize


### PR DESCRIPTION
- created a custom hook to read window width and store state related to which breakpoint is currently active
- replaced useEffect in nav that had similar logic to now pull from custom `useBreakpointSize` hook
- added breakpoint hook to framer motion transition file. If on mobile breakpoint, we do not use framer motion