### PR TITLE
Ezpz cu 369rqzv: Create Forgot Password Page

### DIFF
--- a/components/loader/Loader.module.scss
+++ b/components/loader/Loader.module.scss
@@ -1,0 +1,91 @@
+.cssloadtriangles {
+    transform: translate(-50%, -50%);
+    height: 79px;
+    width: 88px;
+    position: relative;
+    left: 50%;
+    transition: 5s;
+
+    top: 50%;
+    padding-bottom: 8.6rem;
+}
+
+.cssloadtri {
+    position: absolute;
+    animation: cssload-pulse 862.5ms ease-in infinite;
+    border-top: 26px solid var(--seagreen500);
+    border-left: 15px solid transparent;
+    border-right: 15px solid transparent;
+    border-bottom: 0px;
+}
+
+.cssloadtri.cssloadinvert {
+    border-top: 0px;
+    border-bottom: 26px solid var(--seagreen400);
+    border-left: 15px solid transparent;
+    border-right: 15px solid transparent;
+}
+
+.cssloadtri:nth-child(1) {
+    left: 29px;
+}
+
+.cssloadtri:nth-child(2) {
+    left: 15px;
+    top: 26px;
+    animation-delay: -143.75ms;
+}
+
+.cssloadtri:nth-child(3) {
+    left: 29px;
+    top: 26px;
+}
+
+.cssloadtri:nth-child(4) {
+    left: 44px;
+    top: 26px;
+    animation-delay: -718.75ms;
+}
+
+.cssloadtri:nth-child(5) {
+    top: 53px;
+    animation-delay: -287.5ms;
+}
+
+.cssloadtri:nth-child(6) {
+    top: 53px;
+    left: 15px;
+    animation-delay: -287.5ms;
+}
+
+.cssloadtri:nth-child(7) {
+    top: 53px;
+    left: 29px;
+    animation-delay: -431.25ms;
+}
+
+.cssloadtri:nth-child(8) {
+    top: 53px;
+    left: 44px;
+    animation-delay: -575ms;
+}
+
+.cssloadtri:nth-child(9) {
+    top: 53px;
+    left: 58px;
+    animation-delay: -575ms;
+}
+
+@keyframes cssload-pulse {
+    0% {
+        opacity: 1;
+    }
+
+    16.666% {
+        opacity: 1;
+    }
+
+    100% {
+        opacity: 0;
+    }
+}

--- a/components/loader/index.tsx
+++ b/components/loader/index.tsx
@@ -1,0 +1,19 @@
+import styles from './Loader.module.scss'
+
+const Loader = () => {
+    return (
+        <div className={styles.cssloadtriangles}>
+            <div className={`${styles.cssloadtri} ${styles.cssloadinvert}`} />
+            <div className={`${styles.cssloadtri} ${styles.cssloadinvert}`} />
+            <div className={`${styles.cssloadtri}`} />
+            <div className={`${styles.cssloadtri} ${styles.cssloadinvert}`} />
+            <div className={`${styles.cssloadtri} ${styles.cssloadinvert}`} />
+            <div className={`${styles.cssloadtri}`} />
+            <div className={`${styles.cssloadtri} ${styles.cssloadinvert}`} />
+            <div className={`${styles.cssloadtri}`} />
+            <div className={`${styles.cssloadtri} ${styles.cssloadinvert}`} />
+        </div>
+    )
+}
+
+export default Loader

--- a/components/views/auth/AuthPages.module.scss
+++ b/components/views/auth/AuthPages.module.scss
@@ -9,24 +9,23 @@
         box-shadow: var(--form-box-shadow);
         padding: 2rem;
         display: grid;
-        grid-template-rows: 3rem 1fr;
+        grid-template-rows: auto auto;
         grid-gap: 1.5rem;
+        width: 30rem;
 
         .header {
             text-align: center;
             color: var(--off-white);
         }
-        .errorField {
+
+        .success {
+            padding: 1rem;
+            background-color: var(--success-background);
+        }
+
+        .error {
+            padding: 1rem;
             background-color: var(--error-background);
-            color: var(--off-black);
-            padding: 1rem 0.5rem;
-            margin-bottom: 1.5rem;
-            display: flex;
-            align-items: center;
-            column-gap: 0.2rem;
-            .errorIcon {
-                font-size: 1.2rem;
-            }
         }
 
         fieldset {

--- a/components/views/auth/ForgotPassword.tsx
+++ b/components/views/auth/ForgotPassword.tsx
@@ -1,35 +1,32 @@
 import { useState, FormEvent, useEffect } from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 
 import { FormProps } from '../../../utilities/types/formTypes'
-import styles from './AuthPages.module.scss'
 import useForm from '../../../utilities/hooks/useForm'
-
-import { VALID_EMAIL, VALID_PASSWORD } from '../../../utilities/regex'
-import { StringField, FormRow, PasswordField } from '../../form'
+import styles from './AuthPages.module.scss'
+import { VALID_EMAIL } from '../../../utilities/regex'
+import { StringField, FormRow } from '../../form'
 
 const INITIAL_STATE = {
-    email: { value: '', error: '' },
-    password: { value: '', error: '' }
+    email: { value: '', error: '' }
 } as FormProps
 
 const VALIDATIONS = {
     email: {
         test: (value: string) => VALID_EMAIL.test(value),
         message: 'Must containt a valid email address (example@test.com)'
-    },
-    password: {
-        test: (value: string) => VALID_PASSWORD.test(value),
-        message: 'Password does not meet requirements'
     }
 }
-
-const Login = () => {
+const ForgotPassword = () => {
+    const router = useRouter()
     const { form, handleChange } = useForm(INITIAL_STATE, VALIDATIONS)
-    const { email, password } = form
+    const { email } = form
     const [disableSubmit, setDisableSubmit] = useState<boolean>(true)
+
     const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault()
+        router.push('/login')
     }
 
     useEffect(() => {
@@ -40,14 +37,13 @@ const Login = () => {
                 isFormValid = false
             }
         })
-
         setDisableSubmit(!isFormValid)
     })
 
     return (
         <div className={styles.content}>
             <div className={styles.formContainer}>
-                <h1 className={styles.header}>Login</h1>
+                <h1 className={styles.header}>Forgot Password</h1>
 
                 <form onSubmit={handleSubmit}>
                     <fieldset>
@@ -62,16 +58,6 @@ const Login = () => {
                                 required
                             />
                         </FormRow>
-                        <FormRow>
-                            <PasswordField
-                                id="password"
-                                name="password"
-                                placeholder="Enter password"
-                                field={password}
-                                onChange={handleChange}
-                                minLength={8}
-                            />
-                        </FormRow>
                         <button
                             className={styles.button}
                             type="submit"
@@ -79,9 +65,9 @@ const Login = () => {
                             Submit
                         </button>
                         <div className={styles.option}>
-                            <Link href="/forgot-password">
+                            <Link href="/login">
                                 <a className={styles.forgotPw}>
-                                    Forgot Password ?
+                                    Remember Password ?
                                 </a>
                             </Link>
                         </div>
@@ -92,4 +78,4 @@ const Login = () => {
     )
 }
 
-export default Login
+export default ForgotPassword

--- a/components/views/auth/ForgotPassword.tsx
+++ b/components/views/auth/ForgotPassword.tsx
@@ -1,6 +1,5 @@
 import { useState, FormEvent, useEffect } from 'react'
 import Link from 'next/link'
-import { useRouter } from 'next/router'
 
 import { FormProps } from '../../../utilities/types/formTypes'
 import useForm from '../../../utilities/hooks/useForm'
@@ -23,7 +22,6 @@ const VALIDATIONS = {
 }
 
 const ForgotPassword = () => {
-    const router = useRouter()
     const { form, handleChange, handleReset } = useForm(
         INITIAL_STATE,
         VALIDATIONS

--- a/components/views/auth/ForgotPassword.tsx
+++ b/components/views/auth/ForgotPassword.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { FormProps } from '../../../utilities/types/formTypes'
 import useForm from '../../../utilities/hooks/useForm'
 import styles from './AuthPages.module.scss'
-import { VALID_EMAIL } from '../../../utilities/regex'
+import FormValidations from '../../../utilities/validations/forms'
 import { StringField, FormRow } from '../../form'
 
 const ERROR = 'error'
@@ -15,10 +15,7 @@ const INITIAL_STATE = {
 } as FormProps
 
 const VALIDATIONS = {
-    email: {
-        test: (value: string) => VALID_EMAIL.test(value),
-        message: 'Must containt a valid email address (example@test.com)'
-    }
+    email: FormValidations.validEmail
 }
 
 const ForgotPassword = () => {

--- a/components/views/auth/ForgotPassword.tsx
+++ b/components/views/auth/ForgotPassword.tsx
@@ -23,6 +23,7 @@ const ForgotPassword = () => {
     const { form, handleChange } = useForm(INITIAL_STATE, VALIDATIONS)
     const { email } = form
     const [disableSubmit, setDisableSubmit] = useState<boolean>(true)
+    const [error, setError] = useState<boolean>(true)
 
     const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault()

--- a/components/views/auth/ForgotPassword.tsx
+++ b/components/views/auth/ForgotPassword.tsx
@@ -8,6 +8,9 @@ import styles from './AuthPages.module.scss'
 import { VALID_EMAIL } from '../../../utilities/regex'
 import { StringField, FormRow } from '../../form'
 
+const ERROR = 'error'
+const SUCCESS = 'success'
+
 const INITIAL_STATE = {
     email: { value: '', error: '' }
 } as FormProps
@@ -18,16 +21,29 @@ const VALIDATIONS = {
         message: 'Must containt a valid email address (example@test.com)'
     }
 }
+
 const ForgotPassword = () => {
     const router = useRouter()
-    const { form, handleChange } = useForm(INITIAL_STATE, VALIDATIONS)
+    const { form, handleChange, handleReset } = useForm(
+        INITIAL_STATE,
+        VALIDATIONS
+    )
     const { email } = form
     const [disableSubmit, setDisableSubmit] = useState<boolean>(true)
-    const [error, setError] = useState<boolean>(true)
+    const [alert, setAlert] = useState<{ type: string; email: string }>({
+        type: '',
+        email: ''
+    })
+    const [showBanner, setShowBanner] = useState<boolean>(false)
 
     const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault()
-        router.push('/login')
+        setAlert({
+            type: SUCCESS,
+            email: email.value
+        })
+        setShowBanner(true)
+        handleReset()
     }
 
     useEffect(() => {
@@ -41,11 +57,29 @@ const ForgotPassword = () => {
         setDisableSubmit(!isFormValid)
     })
 
+    const BannerDisplay = () => {
+        const { type, email } = alert
+
+        if (type === SUCCESS)
+            return (
+                <div className={styles.success}>
+                    An email has been sent to {email} with a link to reset your
+                    password.
+                </div>
+            )
+        if (type === ERROR)
+            return (
+                <div className={styles.error}> {email} has not been found </div>
+            )
+
+        return <div />
+    }
+
     return (
         <div className={styles.content}>
             <div className={styles.formContainer}>
                 <h1 className={styles.header}>Forgot Password</h1>
-
+                {showBanner && <BannerDisplay />}
                 <form onSubmit={handleSubmit}>
                     <fieldset>
                         <FormRow>

--- a/components/views/auth/Login.tsx
+++ b/components/views/auth/Login.tsx
@@ -5,7 +5,7 @@ import { FormProps } from '../../../utilities/types/formTypes'
 import styles from './AuthPages.module.scss'
 import useForm from '../../../utilities/hooks/useForm'
 
-import { VALID_EMAIL, VALID_PASSWORD } from '../../../utilities/regex'
+import FormValidations from '../../../utilities/validations/forms'
 import { StringField, FormRow, PasswordField } from '../../form'
 
 const INITIAL_STATE = {
@@ -14,14 +14,8 @@ const INITIAL_STATE = {
 } as FormProps
 
 const VALIDATIONS = {
-    email: {
-        test: (value: string) => VALID_EMAIL.test(value),
-        message: 'Must containt a valid email address (example@test.com)'
-    },
-    password: {
-        test: (value: string) => VALID_PASSWORD.test(value),
-        message: 'Password does not meet requirements'
-    }
+    email: FormValidations.validEmail,
+    password: FormValidations.validPassword
 }
 
 const Login = () => {
@@ -78,7 +72,7 @@ const Login = () => {
                             Submit
                         </button>
                         <div className={styles.option}>
-                            <Link href="/forgot-password">
+                            <Link href="/password/forgot">
                                 <a className={styles.forgotPw}>
                                     Forgot Password ?
                                 </a>

--- a/components/views/auth/Login.tsx
+++ b/components/views/auth/Login.tsx
@@ -48,7 +48,6 @@ const Login = () => {
         <div className={styles.content}>
             <div className={styles.formContainer}>
                 <h1 className={styles.header}>Login</h1>
-
                 <form onSubmit={handleSubmit}>
                     <fieldset>
                         <FormRow>

--- a/components/views/auth/Register.tsx
+++ b/components/views/auth/Register.tsx
@@ -2,11 +2,7 @@ import { useState, FormEvent, useEffect } from 'react'
 import useForm from '../../../utilities/hooks/useForm'
 import Link from 'next/link'
 import { FormProps } from '../../../utilities/types/formTypes'
-import {
-    VALID_STRING,
-    VALID_EMAIL,
-    VALID_PASSWORD
-} from '../../../utilities/validations/regexValidators'
+import FormValidations from '../../../utilities/validations/forms'
 import { StringField, FormRow, PasswordField } from '../../form'
 import styles from './AuthPages.module.scss'
 
@@ -17,24 +13,11 @@ const INITIAL_STATE = {
     password: { value: '', error: '' }
 } as FormProps
 
-const NAME_ERROR_MESSAGE = 'Field can only contain alphabetic characters'
 const VALIDATIONS = {
-    firstName: {
-        test: (value: string) => VALID_STRING.test(value),
-        message: NAME_ERROR_MESSAGE
-    },
-    lastName: {
-        test: (value: string) => VALID_STRING.test(value),
-        message: NAME_ERROR_MESSAGE
-    },
-    email: {
-        test: (value: string) => VALID_EMAIL.test(value),
-        message: 'Must containt a valid email address (example@test.com)'
-    },
-    password: {
-        test: (value: string) => VALID_PASSWORD.test(value),
-        message: 'Password does not meet requirements'
-    }
+    firstName: FormValidations.validAlphaString,
+    lastName: FormValidations.validAlphaString,
+    email: FormValidations.validEmail,
+    password: FormValidations.validPassword
 }
 
 const Register = () => {

--- a/components/views/auth/ResetPassword.tsx
+++ b/components/views/auth/ResetPassword.tsx
@@ -2,8 +2,9 @@ import { useState, FormEvent, useEffect } from 'react'
 
 import useForm from '../../../utilities/hooks/useForm'
 import { FormProps } from '../../../utilities/types/formTypes'
-import { VALID_PASSWORD } from '../../../utilities/validations/regexValidators'
+import { VALID_PASSWORD } from '../../../utilities/validations/regex'
 import { FormRow, PasswordField } from '../../form'
+import FormValidations from '../../../utilities/validations/forms'
 import styles from './AuthPages.module.scss'
 
 const INITIAL_STATE = {
@@ -12,15 +13,8 @@ const INITIAL_STATE = {
 } as FormProps
 
 const VALIDATIONS = {
-    newPassword: {
-        test: (value: string) => VALID_PASSWORD.test(value),
-        message:
-            'Password is required, and should include at least 1 lowercase & uppercase letter, 1 special character, 1 number, and be minimum 8 characters long.'
-    },
-    confirmPassword: {
-        test: (value: string) => false,
-        message: 'Passwords do not match'
-    }
+    newPassword: FormValidations.validPassword,
+    confirmPassword: FormValidations.validConfirmedPassword
 }
 
 const ResetPassword = () => {
@@ -70,7 +64,7 @@ const ResetPassword = () => {
                                 onChange={handleChange}
                                 minLength={8}
                                 title="Custom"
-                                showMessage={true}
+                                showMessage
                                 confirmationField={newPassword}
                             />
                         </FormRow>

--- a/components/views/auth/ResetPassword.tsx
+++ b/components/views/auth/ResetPassword.tsx
@@ -58,7 +58,7 @@ const ResetPassword = () => {
                                 onChange={handleChange}
                                 minLength={8}
                                 title="Custom"
-                                message={false}
+                                showMessage={false}
                             />
                         </FormRow>
                         <FormRow>
@@ -70,7 +70,7 @@ const ResetPassword = () => {
                                 onChange={handleChange}
                                 minLength={8}
                                 title="Custom"
-                                message={true}
+                                showMessage={true}
                                 confirmationField={newPassword}
                             />
                         </FormRow>

--- a/pages/forgot-password.tsx
+++ b/pages/forgot-password.tsx
@@ -1,0 +1,7 @@
+import ForgotPassword from '../components/views/auth/ForgotPassword'
+
+const ForgotPasswordPage = () => {
+    return <ForgotPassword />
+}
+
+export default ForgotPasswordPage

--- a/pages/password/forgot/index.tsx
+++ b/pages/password/forgot/index.tsx
@@ -1,4 +1,4 @@
-import ForgotPassword from '../components/views/auth/ForgotPassword'
+import ForgotPassword from '../../../components/views/auth/ForgotPassword'
 
 const ForgotPasswordPage = () => {
     return <ForgotPassword />

--- a/styles/theme.scss
+++ b/styles/theme.scss
@@ -16,6 +16,7 @@
     --off-white: #e8e8e8;
     --error-font: #ff4747;
     --error-background: rgba(255, 71, 71, 0.95);
+    --success-background: rgba(114, 255, 71, 0.95);
 
     --form-box-shadow: 0 4px 30px rgb(0 0 0 / 10%);
     --dark-clear-bg: rgba(3, 3, 3, 0.2);

--- a/utilities/hooks/useForm.ts
+++ b/utilities/hooks/useForm.ts
@@ -14,8 +14,7 @@ function reducer(state: FormProps, action: ActionState) {
             return { ...state, [name]: { value, error } }
         }
         case RESET: {
-            const { initialState } = action.payload
-            return initialState
+            return action.payload
         }
 
         default:

--- a/utilities/types/formTypes.ts
+++ b/utilities/types/formTypes.ts
@@ -35,8 +35,22 @@ type ResetValidationProps = {
     confirmPassword: validationType
 }
 
+type ForgotPasswordProps = {
+    email: inputType
+}
+
+type ForgotValidationProps = {
+    [email: string]: validationType
+}
+
 export type RegisterProps =
     | RegisterValidationProps
     | LoginValidationProps
     | ResetValidationProps
-export type FormProps = RegisterFormProps | LoginFormProps | ResetPasswordProps
+    | ForgotValidationProps
+
+export type FormProps =
+    | RegisterFormProps
+    | LoginFormProps
+    | ResetPasswordProps
+    | ForgotPasswordProps

--- a/utilities/validations/forms.ts
+++ b/utilities/validations/forms.ts
@@ -1,0 +1,29 @@
+import { VALID_EMAIL, VALID_ALPHA_STRING, VALID_PASSWORD } from './regex'
+
+const validEmail = {
+    test: (value: string) => VALID_EMAIL.test(value),
+    message: 'Must containt a valid email address (example@test.com)'
+}
+
+const validAlphaString = {
+    test: (value: string) => VALID_ALPHA_STRING.test(value),
+    message: 'Field can only contain alpha characters'
+}
+
+const validPassword = {
+    test: (value: string) => VALID_PASSWORD.test(value),
+    message:
+        'Password is required, and should include at least 1 lowercase & uppercase letter, 1 special character, 1 number, and be minimum 8 characters long.'
+}
+
+const validConfirmedPassword = {
+    test: (value: string) => false,
+    message: 'Passwords do not match'
+}
+const FormValidations = {
+    validEmail,
+    validAlphaString,
+    validPassword,
+    validConfirmedPassword
+}
+export default FormValidations

--- a/utilities/validations/regex.ts
+++ b/utilities/validations/regex.ts
@@ -1,7 +1,8 @@
-export const VALID_PASSWORD =
-    /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*]).{8,}$/
+export const VALID_ALPHA_STRING = /^[A-Za-z]+$/
 export const VALID_EMAIL =
     /^([0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*@([0-9a-zA-Z][-\w]*[0-9a-zA-Z]\.)+[a-zA-Z]{2,9})$/
+export const VALID_PASSWORD =
+    /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[!?@#$%^&*]).{8,}$/
 export const VALID_FLOATS = /^[+]?([0-9]+\.?[0-9]*|\.[0-9]+)$/
 export const FLOAT_WITH_2_DIGITS = /^(\d+(\.\d{0,2})?|\.?\d{1,2})$/
 export const FLOAT_WITH_1_DIGIT = /^(\d+(\.\d{0,1})?|\.?\d{1,2})$/

--- a/utilities/validations/regexValidators.ts
+++ b/utilities/validations/regexValidators.ts
@@ -1,5 +1,0 @@
-export const VALID_STRING = /^[A-Za-z]+$/
-export const VALID_EMAIL =
-    /^([0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*@([0-9a-zA-Z][-\w]*[0-9a-zA-Z]\.)+[a-zA-Z]{2,9})$/
-export const VALID_PASSWORD =
-    /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[!?@#$%^&*]).{8,}$/


### PR DESCRIPTION
- Created forgot password page linked to `/forgot-password`
- The email field is hooked up to the useForm hook.
- Upon submitting an alert banner will show and clear the form.
- Combined regex.ts and regexValidators.ts .. Remamed to regex.ts
- Moved validations to be exported form /validations/forms.ts to be used on form validation files.
*****
***Side Tasks ?***
- Added in a loader for future use cause i saw it on IG and i liked it. 
- Fixed width of the forms to sit at `30rem` because overall i think they all looked better like this.
***Side note***
- I did some shit possibly .. idk we shall seee .
