### PR TITLE
EZPZ_CU-44yb0vr: Send Reset Password Email

### DIFF
--- a/components/form/button/Button.module.scss
+++ b/components/form/button/Button.module.scss
@@ -1,0 +1,27 @@
+.Button {
+    cursor: pointer;
+    text-decoration: none;
+    position: relative;
+    width: 100%;
+    height: 2rem;
+    display: flex;
+    justify-content: center;
+    margin: 9px auto;
+    font-size: 17px;
+    color: var(--off-white);
+    padding: 8px;
+    border-radius: 6px;
+    border: none;
+    background: rgba(3, 3, 3, 0.1);
+    -webkit-transition: all 2s ease-in-out;
+    -moz-transition: all 2s ease-in-out;
+    -o-transition: all 2s ease-in-out;
+    transition: all 0.2s ease-in-out;
+    &:hover {
+        background: rgba(3, 3, 3, 0.648);
+    }
+    &:disabled {
+        background: rgba(3, 3, 3, 0.1);
+        cursor: not-allowed;
+    }
+}

--- a/components/form/button/Button.module.scss
+++ b/components/form/button/Button.module.scss
@@ -3,13 +3,12 @@
     text-decoration: none;
     position: relative;
     width: 100%;
-    height: 2rem;
     display: flex;
     justify-content: center;
     margin: 9px auto;
     font-size: 17px;
     color: var(--off-white);
-    padding: 8px;
+    padding: 12px;
     border-radius: 6px;
     border: none;
     background: rgba(3, 3, 3, 0.1);

--- a/components/form/button/SubmitButton.tsx
+++ b/components/form/button/SubmitButton.tsx
@@ -1,0 +1,20 @@
+import CircleLoader from '../../loader/circle'
+import styles from './Button.module.scss'
+
+const SubmitButton = ({
+    loading,
+    disabled,
+    label
+}: {
+    loading: boolean
+    disabled: boolean
+    label: string
+}) => {
+    return (
+        <button className={styles.Button} type="submit" disabled={disabled}>
+            {loading ? <CircleLoader /> : label}
+        </button>
+    )
+}
+
+export default SubmitButton

--- a/components/form/index.tsx
+++ b/components/form/index.tsx
@@ -1,5 +1,6 @@
 import StringField from './fields/StringField'
 import PasswordField from './fields/PasswordField'
 import FormRow from './row'
+import SubmitButton from './button/SubmitButton'
 
-export { StringField, FormRow, PasswordField }
+export { StringField, FormRow, PasswordField, SubmitButton }

--- a/components/views/auth/AuthPages.module.scss
+++ b/components/views/auth/AuthPages.module.scss
@@ -38,34 +38,6 @@
                 margin-bottom: 1rem;
             }
 
-            .button {
-                cursor: pointer;
-                text-decoration: none;
-                position: relative;
-                width: 100%;
-                height: 2rem;
-                display: flex;
-                justify-content: center;
-                margin: 9px auto;
-                font-size: 17px;
-                color: var(--off-white);
-                padding: 8px;
-                border-radius: 6px;
-                border: none;
-                background: rgba(3, 3, 3, 0.1);
-                -webkit-transition: all 2s ease-in-out;
-                -moz-transition: all 2s ease-in-out;
-                -o-transition: all 2s ease-in-out;
-                transition: all 0.2s ease-in-out;
-                &:hover {
-                    background: rgba(3, 3, 3, 0.648);
-                }
-                &:disabled {
-                    background: rgba(3, 3, 3, 0.1);
-                    cursor: not-allowed;
-                }
-            }
-
             .option {
                 text-align: center;
                 color: var(--off-white);

--- a/components/views/auth/ForgotPassword.tsx
+++ b/components/views/auth/ForgotPassword.tsx
@@ -1,11 +1,16 @@
 import { useState, FormEvent, useEffect } from 'react'
 import Link from 'next/link'
 
+import {
+    showBanner,
+    showTechnicalDifficultiesBanner
+} from '../../../lib/redux/slices/banner'
 import { FormProps } from '../../../utilities/types/formTypes'
 import useForm from '../../../utilities/hooks/useForm'
-import styles from './AuthPages.module.scss'
 import FormValidations from '../../../utilities/validations/forms'
 import { StringField, FormRow } from '../../form'
+import SubmitButton from '../../form/button/SubmitButton'
+import styles from './AuthPages.module.scss'
 
 const ERROR = 'error'
 const SUCCESS = 'success'
@@ -25,6 +30,7 @@ const ForgotPassword = () => {
     )
     const { email } = form
     const [disableSubmit, setDisableSubmit] = useState<boolean>(true)
+    const [loading, setLoading] = useState<boolean>(false)
     const [alert, setAlert] = useState<{ type: string; email: string }>({
         type: '',
         email: ''
@@ -88,12 +94,11 @@ const ForgotPassword = () => {
                                 required
                             />
                         </FormRow>
-                        <button
-                            className={styles.button}
-                            type="submit"
-                            disabled={disableSubmit}>
-                            Submit
-                        </button>
+                        <SubmitButton
+                            disabled={disableSubmit}
+                            label="Submit"
+                            loading={loading}
+                        />
                         <div className={styles.option}>
                             <Link href="/login">
                                 <a className={styles.forgotPw}>

--- a/components/views/auth/Login.tsx
+++ b/components/views/auth/Login.tsx
@@ -13,11 +13,11 @@ import { AppDispatch } from '../../../lib/redux/store'
 import { LOGIN } from '../../../lib/gql/mutations/users'
 import { JWT_SECRET } from '../../../utilities/constants'
 import { FormProps } from '../../../utilities/types/formTypes'
-import styles from './AuthPages.module.scss'
 import useForm from '../../../utilities/hooks/useForm'
 import FormValidations from '../../../utilities/validations/forms'
 import { StringField, FormRow, PasswordField } from '../../form'
 import CircleLoader from '../../loader/circle'
+import styles from './AuthPages.module.scss'
 
 const INITIAL_STATE = {
     email: { value: '', error: '' },

--- a/components/views/auth/Login.tsx
+++ b/components/views/auth/Login.tsx
@@ -15,8 +15,7 @@ import { JWT_SECRET } from '../../../utilities/constants'
 import { FormProps } from '../../../utilities/types/formTypes'
 import useForm from '../../../utilities/hooks/useForm'
 import FormValidations from '../../../utilities/validations/forms'
-import { StringField, FormRow, PasswordField } from '../../form'
-import CircleLoader from '../../loader/circle'
+import { StringField, FormRow, PasswordField, SubmitButton } from '../../form'
 import styles from './AuthPages.module.scss'
 
 const INITIAL_STATE = {
@@ -126,12 +125,11 @@ const Login = () => {
                                 minLength={8}
                             />
                         </FormRow>
-                        <button
-                            className={styles.button}
-                            type="submit"
-                            disabled={disableSubmit}>
-                            {user?.loading ? <CircleLoader /> : 'Submit'}
-                        </button>
+                        <SubmitButton
+                            label="Submit"
+                            disabled={disableSubmit}
+                            loading={user.loading}
+                        />
                         <div className={styles.option}>
                             <Link href="/password/forgot">
                                 <a className={styles.forgotPw}>

--- a/components/views/auth/Register.tsx
+++ b/components/views/auth/Register.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useDispatch, useSelector } from 'react-redux'
 import { useMutation } from '@apollo/client'
+
 import {
     showTechnicalDifficultiesBanner,
     showBanner
@@ -12,11 +13,11 @@ import { StringField, FormRow, PasswordField } from '../../form'
 import { FormProps } from '../../../utilities/types/formTypes'
 import { JWT_SECRET } from '../../../utilities/constants'
 import FormValidations from '../../../utilities/validations/forms'
-import styles from './AuthPages.module.scss'
 import { AppDispatch } from '../../../lib/redux/store'
 import { REGISTER } from '../../../lib/gql/mutations/users'
 import CircleLoader from '../../loader/circle'
 import { setLoading, setProfile } from '../../../lib/redux/slices/user'
+import styles from './AuthPages.module.scss'
 
 const INITIAL_STATE = {
     firstName: { value: '', error: '' },

--- a/components/views/auth/Register.tsx
+++ b/components/views/auth/Register.tsx
@@ -9,13 +9,12 @@ import {
     showBanner
 } from '../../../lib/redux/slices/banner'
 import useForm from '../../../utilities/hooks/useForm'
-import { StringField, FormRow, PasswordField } from '../../form'
+import { StringField, FormRow, PasswordField, SubmitButton } from '../../form'
 import { FormProps } from '../../../utilities/types/formTypes'
 import { JWT_SECRET } from '../../../utilities/constants'
 import FormValidations from '../../../utilities/validations/forms'
 import { AppDispatch } from '../../../lib/redux/store'
 import { REGISTER } from '../../../lib/gql/mutations/users'
-import CircleLoader from '../../loader/circle'
 import { setLoading, setProfile } from '../../../lib/redux/slices/user'
 import styles from './AuthPages.module.scss'
 
@@ -155,12 +154,11 @@ const Register = () => {
                                 showMessage={true}
                             />
                         </FormRow>
-                        <button
-                            className={styles.button}
-                            type="submit"
-                            disabled={disableSubmit}>
-                            {user?.loading ? <CircleLoader /> : 'Submit'}
-                        </button>
+                        <SubmitButton
+                            label="Submit"
+                            disabled={disableSubmit}
+                            loading={user.loading}
+                        />
                         <div className={styles.option}>
                             Already a user?
                             <Link href="/login">

--- a/components/views/auth/ResetPassword.tsx
+++ b/components/views/auth/ResetPassword.tsx
@@ -2,8 +2,7 @@ import { useState, FormEvent, useEffect } from 'react'
 
 import useForm from '../../../utilities/hooks/useForm'
 import { FormProps } from '../../../utilities/types/formTypes'
-import { VALID_PASSWORD } from '../../../utilities/validations/regex'
-import { FormRow, PasswordField } from '../../form'
+import { FormRow, PasswordField, SubmitButton } from '../../form'
 import FormValidations from '../../../utilities/validations/forms'
 import styles from './AuthPages.module.scss'
 
@@ -68,12 +67,11 @@ const ResetPassword = () => {
                                 confirmationField={newPassword}
                             />
                         </FormRow>
-                        <button
-                            className={styles.button}
-                            type="submit"
-                            disabled={disableSubmit}>
-                            Submit
-                        </button>
+                        <SubmitButton
+                            label="Submit"
+                            disabled={disableSubmit}
+                            loading={false}
+                        />
                     </fieldset>
                 </form>
             </div>

--- a/lib/gql/mutations/users.ts
+++ b/lib/gql/mutations/users.ts
@@ -50,3 +50,24 @@ export const REGISTER = gql`
         }
     }
 `
+
+export const SEND_PASSWORD_RESET = gql`
+    mutation SendResetPasswordEmail($email: String!) {
+        sendPasswordResetEmail(email: $email) {
+            ... on UserSuccess {
+                _id
+                email
+                password
+                firstName
+                lastName
+                token
+                passwordResetToken
+                successType
+            }
+            ... on Errors {
+                type
+                message
+            }
+        }
+    }
+`

--- a/lib/gql/mutations/users.ts
+++ b/lib/gql/mutations/users.ts
@@ -52,7 +52,7 @@ export const REGISTER = gql`
 `
 
 export const SEND_PASSWORD_RESET = gql`
-    mutation SendResetPasswordEmail($email: String!) {
+    mutation sendResetPasswordEmail($email: String!) {
         sendPasswordResetEmail(email: $email) {
             ... on UserSuccess {
                 _id

--- a/lib/redux/slices/banner.ts
+++ b/lib/redux/slices/banner.ts
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit'
+import { Action, createSlice } from '@reduxjs/toolkit'
 
 const initialState = {
     show: false as boolean,


### PR DESCRIPTION
- Created reusable `SubmitButton` with built in loader
  - Replaced regular button in all 4 forms with new `SubmitButton`
- Hooked up ForgotPassword component with GQL/mutation for `SEND_PASSWORD_EMAIL` 
  - Decided to use `useState` instead of redux for loading state of this component. This is isolated to this component, there is never a time where this component extends into the user state, therefore, we don't touch the user slice at all. Keep things tight and controlled here. 
