### PR TITLE
EZPZ_CU-44ygeph: Form Status added to useFormHook

### DIFF
--- a/components/form/fields/StringField/FormField.module.scss
+++ b/components/form/fields/StringField/FormField.module.scss
@@ -21,7 +21,6 @@ $label-top-focus: -1.3rem;
     }
     input {
         position: relative;
-        margin-bottom: 0.5rem;
         width: 100%;
         display: block;
         font-size: 1rem;

--- a/components/form/row/FormRow.module.scss
+++ b/components/form/row/FormRow.module.scss
@@ -2,8 +2,8 @@
 
 .FormRow {
     display: flex;
-
-    gap: 1rem 1rem;
+    gap: 1rem;
+    margin: 1rem 0;
 
     & > * {
         flex: 1;

--- a/components/views/auth/ForgotPassword.tsx
+++ b/components/views/auth/ForgotPassword.tsx
@@ -27,12 +27,11 @@ const VALIDATIONS = {
 const ForgotPassword = () => {
     const dispatch = useDispatch<AppDispatch>()
 
-    const { form, handleChange, handleReset } = useForm(
+    const { form, handleChange, handleReset, isFormValid } = useForm(
         INITIAL_STATE,
         VALIDATIONS
     )
     const { email } = form
-    const [disableSubmit, setDisableSubmit] = useState<boolean>(true)
     const [loading, setLoading] = useState<boolean>(false)
 
     const [sendResetPasswordEmail] = useMutation(SEND_PASSWORD_RESET, {
@@ -68,20 +67,8 @@ const ForgotPassword = () => {
 
     const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault()
-
         sendResetPasswordEmail()
     }
-
-    useEffect(() => {
-        let isFormValid = true
-        Object.keys(form).forEach(item => {
-            const current = form[item]
-            if ((isFormValid && !current.value) || current.error) {
-                isFormValid = false
-            }
-        })
-        setDisableSubmit(!isFormValid)
-    })
 
     return (
         <div className={styles.content}>
@@ -101,7 +88,7 @@ const ForgotPassword = () => {
                             />
                         </FormRow>
                         <SubmitButton
-                            disabled={disableSubmit}
+                            disabled={!isFormValid}
                             label="Submit"
                             loading={loading}
                         />

--- a/components/views/auth/Login.tsx
+++ b/components/views/auth/Login.tsx
@@ -33,12 +33,11 @@ const Login = () => {
     const router = useRouter()
 
     const user = useSelector((state: any) => state.user)
-    const { form, handleChange, handleReset } = useForm(
+    const { form, handleChange, handleReset, isFormValid } = useForm(
         INITIAL_STATE,
         VALIDATIONS
     )
     const { email, password } = form
-    const [disableSubmit, setDisableSubmit] = useState<boolean>(true)
 
     const [login] = useMutation(LOGIN, {
         onCompleted({ login: data }) {
@@ -86,18 +85,6 @@ const Login = () => {
         login()
     }
 
-    useEffect(() => {
-        let isFormValid = true
-        Object.keys(form).forEach(item => {
-            const current = form[item]
-            if ((isFormValid && !current.value) || current.error) {
-                isFormValid = false
-            }
-        })
-
-        setDisableSubmit(!isFormValid)
-    })
-
     return (
         <div className={styles.content}>
             <div className={styles.formContainer}>
@@ -127,7 +114,7 @@ const Login = () => {
                         </FormRow>
                         <SubmitButton
                             label="Submit"
-                            disabled={disableSubmit}
+                            disabled={!isFormValid}
                             loading={user.loading}
                         />
                         <div className={styles.option}>

--- a/components/views/auth/Register.tsx
+++ b/components/views/auth/Register.tsx
@@ -36,13 +36,12 @@ const Register = () => {
     const dispatch = useDispatch<AppDispatch>()
     const router = useRouter()
     const user = useSelector((state: any) => state.user)
-    const { form, handleChange, handleReset } = useForm(
+    const { form, handleChange, handleReset, isFormValid } = useForm(
         INITIAL_STATE,
         VALIDATIONS
     )
 
     const { firstName, lastName, email, password } = form
-    const [disableSubmit, setDisableSubmit] = useState<boolean>(true)
 
     const [register] = useMutation(REGISTER, {
         onCompleted({ register: data }) {
@@ -92,18 +91,6 @@ const Register = () => {
         dispatch(setLoading(true))
         register()
     }
-
-    useEffect(() => {
-        let isFormValid = true
-        Object.keys(form).forEach(item => {
-            const current = form[item]
-            if ((isFormValid && !current.value) || current.error) {
-                isFormValid = false
-            }
-        })
-
-        setDisableSubmit(!isFormValid)
-    })
 
     return (
         <div className={styles.content}>
@@ -156,7 +143,7 @@ const Register = () => {
                         </FormRow>
                         <SubmitButton
                             label="Submit"
-                            disabled={disableSubmit}
+                            disabled={!isFormValid}
                             loading={user.loading}
                         />
                         <div className={styles.option}>

--- a/components/views/auth/ResetPassword.tsx
+++ b/components/views/auth/ResetPassword.tsx
@@ -17,24 +17,15 @@ const VALIDATIONS = {
 }
 
 const ResetPassword = () => {
-    const { form, handleChange } = useForm(INITIAL_STATE, VALIDATIONS)
+    const { form, handleChange, isFormValid } = useForm(
+        INITIAL_STATE,
+        VALIDATIONS
+    )
     const { newPassword, confirmPassword } = form
-    const [disableSubmit, setDisableSubmit] = useState<boolean>(true)
 
     const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault()
     }
-
-    useEffect(() => {
-        let isFormValid = true
-        Object.keys(form).forEach(item => {
-            const current = form[item]
-            if ((isFormValid && !current.value) || current.error) {
-                isFormValid = false
-            }
-        })
-        setDisableSubmit(!isFormValid)
-    })
 
     return (
         <div className={styles.content}>
@@ -69,7 +60,7 @@ const ResetPassword = () => {
                         </FormRow>
                         <SubmitButton
                             label="Submit"
-                            disabled={disableSubmit}
+                            disabled={!isFormValid}
                             loading={false}
                         />
                     </fieldset>

--- a/utilities/hooks/useForm.ts
+++ b/utilities/hooks/useForm.ts
@@ -42,8 +42,11 @@ const useForm = (initialState: FormProps, validations: RegisterProps) => {
     }
 
     const handleReset = () => dispatch({ type: RESET, payload: initialState })
+    const isFormValid = Object.keys(form).every(
+        label => form[label].value && !form[label].error
+    )
 
-    return { form, handleChange, handleReset }
+    return { form, handleChange, handleReset, isFormValid }
 }
 
 export default useForm


### PR DESCRIPTION
- Check against form values & errors within useForm hook, return the overall form status
- Removed useEffect from all 4 forms that were essentially doing the same thing before. The key difference here is, having the form status live inside the useForm hook cuts out an entire render every time. As the form updates, the hook also checks in the same render if the form is valid or not. The useEffect was forcing a 2nd render every time something changed.
- Minor CSS update to form row