### PR TITLE
EZPZ_CU-37k9kme: Input field labels vertical spacing

### DIFF
--- a/components/form/fields/PasswordField/PasswordField.module.scss
+++ b/components/form/fields/PasswordField/PasswordField.module.scss
@@ -1,4 +1,4 @@
-$label-top: 0.9rem;
+$label-top: 0.75rem;
 $label-left: 0.5rem;
 $label-top-focus: -1.3rem;
 

--- a/components/form/fields/StringField/FormField.module.scss
+++ b/components/form/fields/StringField/FormField.module.scss
@@ -1,4 +1,4 @@
-$label-top: 0.9rem;
+$label-top: 0.75rem;
 $label-left: 0.5rem;
 $label-top-focus: -1.3rem;
 


### PR DESCRIPTION
Live:
<img width="496" alt="Screen Shot 2022-11-26 at 3 56 08 PM" src="https://user-images.githubusercontent.com/20602890/204108570-724ca5bf-57f7-4dfd-b8a2-cc92959afe35.png">

Now:
<img width="492" alt="Screen Shot 2022-11-26 at 3 56 42 PM" src="https://user-images.githubusercontent.com/20602890/204108589-8b284349-8f62-421b-a38f-79c14b766f38.png">
